### PR TITLE
Add ebook translation prompt

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -24,6 +24,16 @@ default_prompts = {
         "Preserve the original paragraph structure by merging hard-wrapped lines. Insert a single blank line between paragraphs and standalone titles; otherwise, write continuously. "
         "Remove all page headers, footers, running heads, footnotes, page numbers, and end-of-line hyphens. "
         "Output plain UTF-8 text only, with no comments, metadata, explanations, or leading/trailing spaces on any line."
+    ),
+    # Prompt para traducir en modo eBook (ENGLISH)
+    "ebook_translation_mode": (
+        "Translate the content from the supplied image or PDF into {target_language}. "
+        "Return only the translated text, formatted in valid Markdown. Begin your response with the translated result. "
+        "Use standard Markdown syntax for headings (#), bold, italics, and lists. "
+        "Preserve the original paragraph structure by merging hard-wrapped lines. "
+        "Insert a single blank line between paragraphs and standalone titles; otherwise, write continuously. "
+        "Remove all page headers, footers, running heads, footnotes, page numbers, and end-of-line hyphens. "
+        "Output plain UTF-8 text only—no comments, metadata, explanations, or leading/trailing spaces on any line."
     )
 }
 


### PR DESCRIPTION
## Summary
- add new `ebook_translation_mode` prompt for translating scanned images or PDFs

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c16383e84832e9ad519a27bdfcd78