### PR TITLE
Add Markdown to EPUB conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A simple web app combining OCR, AI-assisted correction, translation and optional
 - **Compression**: optional PDF or image compression after processing.
 - All modes show real-time emoji progress.
 - **TXT to PDF**: convert text files (.txt or .md) into clean PDFs.
+- **Markdown to EPUB**: turn Markdown files into EPUB ebooks.
 - **Translation**: translate PDF or text documents page by page.
 - **Configuration**: manage prompts, models and languages.
 
@@ -65,6 +66,7 @@ A simple web app combining OCR, AI-assisted correction, translation and optional
 2. Upload a file and select **AI**.
 3. Choose a prompt and process the file.
 4. Convert the resulting Markdown text (.txt or .md) to PDF using the **TXT to PDF** tab if needed.
+5. Create an EPUB version using the **MD to EPUB** tab when desired.
 
 ### Optional Compression
 1. Enable compression in the **OCR** tab.

--- a/backend/app.py
+++ b/backend/app.py
@@ -7,7 +7,7 @@ from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 from models import get_models, add_model, get_languages, update_prompt, get_prompt, add_language, delete_prompt, custom_prompts, default_prompts
-from utils import process_file, translate_file_by_pages, convert_txt_to_pdf
+from utils import process_file, translate_file_by_pages, convert_txt_to_pdf, convert_md_to_epub
 import time
 
 app = Flask(__name__, static_folder="static", static_url_path="")
@@ -270,6 +270,21 @@ def txt_to_pdf_endpoint():
     try:
         pdf_path = convert_txt_to_pdf(txt_path)
         return jsonify({"message": "Text to PDF conversion completed", "pdf_file": os.path.basename(pdf_path)})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@app.route('/api/mdtoepub', methods=['POST'])
+def md_to_epub_endpoint():
+    data = request.get_json()
+    filename = data.get("filename")
+    if not filename:
+        return jsonify({"error": "Missing filename parameter"}), 400
+    md_path = os.path.join(OUTPUT_FOLDER, filename)
+    if not os.path.exists(md_path):
+        return jsonify({"error": "File not found"}), 404
+    try:
+        epub_path = convert_md_to_epub(md_path)
+        return jsonify({"message": "Markdown to EPUB conversion completed", "epub_file": os.path.basename(epub_path)})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import FileUpload from './components/FileUpload';
 import FileList from './components/FileList';
 import Configurations from './components/Configurations';
 import TxtToPdf from './components/TxtToPdf';
+import MdToEpub from './components/MdToEpub';
 import Notifications from './components/Notifications';
 
 function App() {
@@ -32,7 +33,8 @@ function App() {
     { id: 'ocrAI', label: 'OCR AI Processing', icon: '🤖', description: 'Upload and process documents with AI' },
     { id: 'files', label: 'Processed Files', icon: '📁', description: 'View and manage processed files' },
     { id: 'configurations', label: 'Settings', icon: '⚙️', description: 'Configure application settings' },
-    { id: 'txttopdf', label: 'TXT to PDF', icon: '📝', description: 'Convert text files to PDF' }
+    { id: 'txttopdf', label: 'TXT to PDF', icon: '📝', description: 'Convert text files to PDF' },
+    { id: 'mdtoepub', label: 'MD to EPUB', icon: '📚', description: 'Convert Markdown files to EPUB' }
   ];
 
   return (
@@ -98,6 +100,7 @@ function App() {
             {activeTab === 'files' && <FileList />}
             {activeTab === 'configurations' && <Configurations />}
             {activeTab === 'txttopdf' && <TxtToPdf />}
+            {activeTab === 'mdtoepub' && <MdToEpub />}
           </div>
         </div>
       </main>

--- a/frontend/src/components/MdToEpub.js
+++ b/frontend/src/components/MdToEpub.js
@@ -1,0 +1,162 @@
+// frontend/src/components/MdToEpub.js
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+const API_URL = '/api';
+
+function MdToEpub() {
+  const [mdFiles, setMdFiles] = useState([]);
+  const [selectedFile, setSelectedFile] = useState('');
+  const [message, setMessage] = useState('');
+  const [epubFile, setEpubFile] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchMdFiles();
+  }, []);
+
+  const fetchMdFiles = async () => {
+    try {
+      const res = await axios.get(`${API_URL}/files`);
+      const files = res.data.files
+        .filter(f => f.name.toLowerCase().endsWith('.md'))
+        .map(f => f.name);
+      setMdFiles(files);
+    } catch (err) {
+      console.error(err);
+      setMessage('❌ Error loading Markdown files.');
+    }
+  };
+
+  const handleConversion = async () => {
+    if (!selectedFile) {
+      setMessage('⚠️ Please select a Markdown file.');
+      return;
+    }
+
+    setLoading(true);
+    setMessage('🔄 Converting Markdown to EPUB...');
+
+    try {
+      const res = await axios.post(`${API_URL}/mdtoepub`, { filename: selectedFile });
+      setMessage(res.data.message);
+      setEpubFile(res.data.epub_file);
+    } catch (err) {
+      console.error(err);
+      setMessage('❌ Error converting Markdown to EPUB.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDownload = () => {
+    if (epubFile) {
+      window.location.href = `${API_URL}/files/${epubFile}`;
+    }
+  };
+
+  return (
+    <div className="txt-to-pdf-container">
+      <div className="card">
+        <div className="card-header">
+          <h3 className="card-title">Markdown to EPUB Converter</h3>
+          <p style={{ color: 'var(--gray-600)', fontSize: '0.875rem', margin: 0 }}>
+            Convert your Markdown files to EPUB format
+          </p>
+        </div>
+
+        <div className="form-group">
+          <label className="form-label">Select Markdown File</label>
+          <select
+            value={selectedFile}
+            onChange={(e) => setSelectedFile(e.target.value)}
+            className="form-select"
+            disabled={loading}
+          >
+            <option value="">-- Choose a .md file --</option>
+            {mdFiles.map((file, idx) => (
+              <option key={idx} value={file}>{file}</option>
+            ))}
+          </select>
+          {mdFiles.length === 0 && (
+            <p style={{
+              fontSize: '0.875rem',
+              color: 'var(--gray-500)',
+              margin: '0.5rem 0 0 0',
+              fontStyle: 'italic'
+            }}>
+              No Markdown files found. Process some documents first.
+            </p>
+          )}
+        </div>
+
+        <div className="form-actions">
+          <button
+            onClick={handleConversion}
+            className="btn btn-primary"
+            disabled={!selectedFile || loading}
+          >
+            {loading ? (
+              <>
+                <div className="spinner"></div>
+                Converting...
+              </>
+            ) : (
+              <>📚 Convert to EPUB</>
+            )}
+          </button>
+
+          <button
+            onClick={fetchMdFiles}
+            className="btn btn-secondary"
+            disabled={loading}
+          >
+            🔄 Refresh Files
+          </button>
+        </div>
+      </div>
+
+      {message && (
+        <div className={`alert ${message.includes('❌') ? 'alert-error' :
+                                message.includes('⚠️') ? 'alert-warning' : 'alert-info'}`}>
+          {message}
+        </div>
+      )}
+
+      {epubFile && (
+        <div className="card success-card">
+          <div className="card-header">
+            <h4 className="card-title">✅ Conversion Complete</h4>
+          </div>
+          <div className="conversion-result">
+            <div className="file-info">
+              <div className="file-icon">📚</div>
+              <div className="file-details">
+                <p className="file-name">{epubFile}</p>
+                <p className="file-description">Your EPUB is ready for download</p>
+              </div>
+            </div>
+            <button
+              onClick={handleDownload}
+              className="btn btn-success"
+            >
+              📥 Download EPUB
+            </button>
+          </div>
+        </div>
+      )}
+
+      {mdFiles.length === 0 && (
+        <div className="empty-state">
+          <div className="empty-state-icon">📄</div>
+          <h3 className="empty-state-title">No Markdown files available</h3>
+          <p className="empty-state-description">
+            Process some documents first to generate Markdown files that can be converted to EPUB
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MdToEpub;


### PR DESCRIPTION
## Summary
- implement `convert_md_to_epub` with proper EPUB packaging
- add `/api/mdtoepub` frontend section
- update README with instructions

## Testing
- `python -m py_compile backend/utils.py backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686c1511b800832e90fe2e3b819a1b53