### PR TITLE
Improve PDF processing progress display

### DIFF
--- a/backend/utils.py
+++ b/backend/utils.py
@@ -160,18 +160,18 @@ def ocr_file_by_pages(file_path, api, model, prompt_key, update_progress, is_can
         total = len(pages)
         for i, page in enumerate(pages, start=1):
             if is_cancelled():
-                update_progress(0, "⏹️ Process cancelled")
+                update_progress(0, "⏹️ Process cancelled", current_page=i, total_pages=total)
                 return "Process cancelled."
             temp_filename = os.path.join(OUTPUT_FOLDER, f"temp_page_{uuid.uuid4().hex}.png")
             page.save(temp_filename, "PNG")
-            update_progress(int((i-1)/total*100), f"🔍 Processing page {i} of {total} (AI OCR)")
+            update_progress(int((i-1)/total*100), f"🔍 Processing page {i} of {total} (AI OCR)", current_page=i, total_pages=total)
             page_text = call_api_ocr(api, model, temp_filename, prompt_key)
             final_text += f"[Page {i:04d}]\n{page_text}\n\n"
             os.remove(temp_filename)
             progress = int((i / total) * 100)
-            update_progress(progress, f"✅ Page {i} of {total} processed (AI OCR)")
+            update_progress(progress, f"✅ Page {i} of {total} processed (AI OCR)", current_page=i, total_pages=total)
             time.sleep(1)
-        update_progress(100, "🎉 AI OCR completed")
+        update_progress(100, "🎉 AI OCR completed", current_page=total, total_pages=total)
         return final_text
     else:
         update_progress(10, "🔍 Processing image with AI OCR")
@@ -190,19 +190,19 @@ def translate_file_by_pages(file_path, api, model, target_language, prompt_key, 
         total = len(pages)
         for i, page in enumerate(pages, start=1):
             if is_cancelled():
-                update_progress(0, "⏹️ Process cancelled")
+                update_progress(0, "⏹️ Process cancelled", current_page=i, total_pages=total)
                 return "Process cancelled."
             temp_filename = os.path.join(OUTPUT_FOLDER, f"temp_page_{uuid.uuid4().hex}.png")
             page.save(temp_filename, "PNG")
-            update_progress(int((i-1)/total*100), f"🌐 Translating page {i} of {total}")
+            update_progress(int((i-1)/total*100), f"🌐 Translating page {i} of {total}", current_page=i, total_pages=total)
             page_text = pytesseract.image_to_string(page, lang='eng')
             translated_page = call_api_translation(api, model, page_text, target_language, prompt_key)
             final_translation += f"# Page {i}\n{translated_page}\n\n"
             os.remove(temp_filename)
             progress = int((i / total) * 100)
-            update_progress(progress, f"✅ Page {i} of {total} translated")
+            update_progress(progress, f"✅ Page {i} of {total} translated", current_page=i, total_pages=total)
             time.sleep(1)
-        update_progress(100, "🎉 Translation completed")
+        update_progress(100, "🎉 Translation completed", current_page=total, total_pages=total)
         return final_translation
     elif file_path.lower().endswith(".txt"):
         update_progress(10, "🌐 Translating full TXT file")

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -609,6 +609,13 @@ body {
   font-size: 0.875rem;
 }
 
+.progress-pages {
+  font-size: 0.75rem;
+  color: var(--gray-600);
+  text-align: center;
+  margin-top: 0.25rem;
+}
+
 /* File List Styles */
 .file-list-container {
   display: grid;

--- a/frontend/src/components/FileUpload.js
+++ b/frontend/src/components/FileUpload.js
@@ -27,6 +27,8 @@ function FileUpload({ onJobCompleted }) {
   const [uploadProgress, setUploadProgress] = useState(0);
   const [message, setMessage] = useState('');
   const [jobId, setJobId] = useState(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
   const [targetLanguage, setTargetLanguage] = useState(DEFAULT_LANGUAGES[0]);
   const [availableLanguages, setAvailableLanguages] = useState(DEFAULT_LANGUAGES);
   
@@ -72,10 +74,18 @@ function FileUpload({ onJobCompleted }) {
             const data = response.data;
             setUploadProgress(data.progress);
             setMessage(data.status);
+            if (data.current_page !== undefined) {
+              setCurrentPage(data.current_page);
+            }
+            if (data.total_pages !== undefined) {
+              setTotalPages(data.total_pages);
+            }
             if (data.progress === 100 || data.status.includes("Cancelled") || data.status.includes("Error")) {
               clearInterval(interval);
               onJobCompleted && onJobCompleted("Processing job completed");
               setJobId(null);
+              setCurrentPage(0);
+              setTotalPages(0);
             }
           })
           .catch(err => console.error(err));
@@ -102,6 +112,8 @@ function FileUpload({ onJobCompleted }) {
         .then(response => {
           setMessage("⏹️ Process stopped by user");
           setJobId(null);
+          setCurrentPage(0);
+          setTotalPages(0);
         })
         .catch(err => console.error(err));
     }
@@ -142,6 +154,9 @@ function FileUpload({ onJobCompleted }) {
     if (mode === 'translation' || mode === 'TRANSLATION' || promptKey === 'translation') {
       formData.append("target_language", targetLanguage);
     }
+
+    setCurrentPage(0);
+    setTotalPages(0);
 
     axios.post(`${API_URL}/upload`, formData, { headers: { "Content-Type": "multipart/form-data" } })
       .then(response => {
@@ -361,7 +376,12 @@ function FileUpload({ onJobCompleted }) {
           <div className="card-header">
             <h3 className="card-title">Processing Status</h3>
           </div>
-          <ProgressBar progress={uploadProgress} status={message} />
+          <ProgressBar
+            progress={uploadProgress}
+            status={message}
+            currentPage={currentPage}
+            totalPages={totalPages}
+          />
         </div>
       )}
 

--- a/frontend/src/components/ProgressBar.js
+++ b/frontend/src/components/ProgressBar.js
@@ -1,21 +1,27 @@
 // frontend/src/components/ProgressBar.js
 import React from 'react';
 
-function ProgressBar({ progress, status }) {
+function ProgressBar({ progress, status, currentPage, totalPages }) {
   return (
     <div className="progress-wrapper">
       <div className="progress-header">
         <span className="progress-label">Processing Progress</span>
         <span className="progress-percentage">{progress}%</span>
       </div>
-      
+
       <div className="progress-container">
-        <div 
+        <div
           className="progress-bar"
           style={{ width: `${progress}%` }}
         />
       </div>
-      
+
+      {totalPages > 0 && (
+        <div className="progress-pages">
+          Page {currentPage} of {totalPages}
+        </div>
+      )}
+
       {status && (
         <div className="progress-text">
           {status}


### PR DESCRIPTION
## Summary
- track current and total pages for running jobs
- expose page data from progress endpoint
- display page count in the UI progress bar
- reset page state on job start and stop

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d2904d980832eb65165e8aec5e607