### PR TITLE
Improve progress bar updates for page-by-page processing

### DIFF
--- a/frontend/src/components/ProgressBar.js
+++ b/frontend/src/components/ProgressBar.js
@@ -2,17 +2,19 @@
 import React from 'react';
 
 function ProgressBar({ progress, status, currentPage, totalPages }) {
+  const displayProgress = Number(progress).toFixed(1);
+  const barWidth = Math.min(progress, 100);
   return (
     <div className="progress-wrapper">
       <div className="progress-header">
         <span className="progress-label">Processing Progress</span>
-        <span className="progress-percentage">{progress}%</span>
+        <span className="progress-percentage">{displayProgress}%</span>
       </div>
 
       <div className="progress-container">
         <div
           className="progress-bar"
-          style={{ width: `${progress}%` }}
+          style={{ width: `${barWidth}%` }}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- show decimal precision for progress bar and cap width
- compute progress using float percentage values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2dc6486c832e8049c61f17f7b5d6