### PR TITLE
Set Markdown as default output

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -35,7 +35,7 @@ def update_progress(job_id, progress, status, current_page=None, total_pages=Non
 def is_cancelled(job_id):
     return active_jobs[job_id]["cancelled"]
 
-def run_processing(job_id, file_path, api, model, mode, prompt_key, compression_settings=None, output_format="txt"):
+def run_processing(job_id, file_path, api, model, mode, prompt_key, compression_settings=None, output_format="md"):
     try:
         result = process_file(
             file_path, api, model, mode, prompt_key,
@@ -75,7 +75,7 @@ def upload_file():
     model = request.form.get('model')
     mode = request.form.get('mode')  # "OCR", "OCR + AI" or "AI"
     prompt_key = request.form.get('prompt_key')
-    output_format = request.form.get('output_format', 'txt').lower()
+    output_format = request.form.get('output_format', 'md').lower()
     
     # Parse compression settings
     compression_settings = None

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -333,7 +333,7 @@ def translate_file_by_pages(file_path, api, model, target_language, prompt_key, 
     else:
         return "Unsupported file type for translation."
 
-def process_file(file_path, api, model, mode, prompt_key, update_progress, is_cancelled, compression_settings=None, output_format="txt"):
+def process_file(file_path, api, model, mode, prompt_key, update_progress, is_cancelled, compression_settings=None, output_format="md"):
     if is_cancelled():
         update_progress(0, "⏹️ Process cancelled")
         return "Process cancelled."

--- a/frontend/src/components/FileUpload.js
+++ b/frontend/src/components/FileUpload.js
@@ -38,7 +38,7 @@ function FileUpload({ onJobCompleted }) {
   const [quality, setQuality] = useState(85);
   const [format, setFormat] = useState('JPEG');
   const [keepOriginal, setKeepOriginal] = useState(false);
-  const [outputFormat, setOutputFormat] = useState('txt');
+  const [outputFormat, setOutputFormat] = useState('md');
 
   const apis = ['Gemini'];
 


### PR DESCRIPTION
## Summary
- default the output format dropdown to `.md`
- let API & utils assume `.md` when no output format is specified

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4409b2b4832eab0607f907a7e617