### PR TITLE
Fix long filename layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1200,6 +1200,7 @@ body {
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .file-info {
@@ -1216,6 +1217,7 @@ body {
 
 .file-details {
   flex: 1;
+  min-width: 0;
 }
 
 .file-name {
@@ -1223,6 +1225,9 @@ body {
   color: var(--gray-900);
   margin: 0 0 0.25rem 0;
   font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .file-description {


### PR DESCRIPTION
## Summary
- allow wrapping in conversion result rows
- ensure file name truncates with ellipsis

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fd64ed34832eae58ed65623f9bb8