### PR TITLE
Add manual upload for txt and md conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ A simple web app combining OCR, AI-assisted correction, translation and optional
   - **AI (Full AI OCR)**: Gemini AI processes each page and outputs Markdown.
 - **Compression**: optional PDF or image compression after processing.
 - All modes show real-time emoji progress.
-- **TXT to PDF**: convert text files (.txt or .md) into clean PDFs.
-- **Markdown to EPUB**: turn Markdown files into EPUB ebooks.
+- **TXT to PDF**: convert text files (.txt or .md) into clean PDFs. Files can be uploaded manually or selected from previous results.
+- **Markdown to EPUB**: turn Markdown files into EPUB ebooks. Supports direct upload or choosing an existing file.
 - **Translation**: translate PDF or text documents page by page.
 - **Configuration**: manage prompts, models and languages.
 
@@ -65,8 +65,8 @@ A simple web app combining OCR, AI-assisted correction, translation and optional
 1. Go to the **OCR** tab.
 2. Upload a file and select **AI**.
 3. Choose a prompt and process the file.
-4. Convert the resulting Markdown text (.txt or .md) to PDF using the **TXT to PDF** tab if needed.
-5. Create an EPUB version using the **MD to EPUB** tab when desired.
+4. Convert the resulting Markdown text (.txt or .md) to PDF using the **TXT to PDF** tab if needed. You can upload a text or Markdown file directly or choose one from the list.
+5. Create an EPUB version using the **MD to EPUB** tab when desired. This section also allows manual Markdown uploads.
 
 ### Optional Compression
 1. Enable compression in the **OCR** tab.

--- a/frontend/src/components/MdToEpub.js
+++ b/frontend/src/components/MdToEpub.js
@@ -7,6 +7,7 @@ const API_URL = '/api';
 function MdToEpub() {
   const [mdFiles, setMdFiles] = useState([]);
   const [selectedFile, setSelectedFile] = useState('');
+  const [uploadFile, setUploadFile] = useState(null);
   const [message, setMessage] = useState('');
   const [epubFile, setEpubFile] = useState('');
   const [loading, setLoading] = useState(false);
@@ -29,8 +30,8 @@ function MdToEpub() {
   };
 
   const handleConversion = async () => {
-    if (!selectedFile) {
-      setMessage('⚠️ Please select a Markdown file.');
+    if (!selectedFile && !uploadFile) {
+      setMessage('⚠️ Please select or upload a Markdown file.');
       return;
     }
 
@@ -38,7 +39,16 @@ function MdToEpub() {
     setMessage('🔄 Converting Markdown to EPUB...');
 
     try {
-      const res = await axios.post(`${API_URL}/mdtoepub`, { filename: selectedFile });
+      let res;
+      if (uploadFile) {
+        const formData = new FormData();
+        formData.append('file', uploadFile);
+        res = await axios.post(`${API_URL}/mdtoepub`, formData, {
+          headers: { 'Content-Type': 'multipart/form-data' }
+        });
+      } else {
+        res = await axios.post(`${API_URL}/mdtoepub`, { filename: selectedFile });
+      }
       setMessage(res.data.message);
       setEpubFile(res.data.epub_file);
     } catch (err) {
@@ -46,6 +56,7 @@ function MdToEpub() {
       setMessage('❌ Error converting Markdown to EPUB.');
     } finally {
       setLoading(false);
+      setUploadFile(null);
     }
   };
 
@@ -90,11 +101,21 @@ function MdToEpub() {
           )}
         </div>
 
+        <div className="form-group">
+          <label className="form-label">Or Upload File</label>
+          <input
+            type="file"
+            accept=".md"
+            onChange={(e) => setUploadFile(e.target.files[0])}
+            disabled={loading}
+          />
+        </div>
+
         <div className="form-actions">
           <button
             onClick={handleConversion}
             className="btn btn-primary"
-            disabled={!selectedFile || loading}
+            disabled={(!selectedFile && !uploadFile) || loading}
           >
             {loading ? (
               <>


### PR DESCRIPTION
## Summary
- allow manual file upload in txt→PDF and md→EPUB backend endpoints
- support uploading files from the UI in TxtToPdf and MdToEpub components
- document new upload ability in README

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875174a0eec832e8574b6b6c005fcf8