### PR TITLE
Add job queue with progress list

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@
 import os
 import uuid
 import threading
+from queue import Queue
 import json
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
@@ -20,7 +21,9 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
 # Global dictionary for background jobs
-active_jobs = {}  # job_id: {"progress": int, "status": str, "cancelled": bool, "result": any, "current_page": int, "total_pages": int}
+active_jobs = {}  # job_id: {"progress": int, "status": str, "cancelled": bool, "result": any, "current_page": int, "total_pages": int, "filename": str}
+# Queue for pending jobs
+job_queue = Queue()
 
 def update_progress(job_id, progress, status, current_page=None, total_pages=None):
     if job_id not in active_jobs:
@@ -65,6 +68,29 @@ def run_translation(job_id, file_path, api, model, target_language, prompt_key):
     except Exception as e:
         update_progress(job_id, active_jobs[job_id]["progress"], f"❌ Error: {str(e)}")
 
+def queue_worker():
+    while True:
+        job = job_queue.get()
+        if job is None:
+            break
+        job_id = job["job_id"]
+        update_progress(job_id, 0, "🚀 Processing started")
+        run_processing(
+            job_id,
+            job["file_path"],
+            job["api"],
+            job["model"],
+            job["mode"],
+            job["prompt_key"],
+            job.get("compression_settings"),
+            job.get("output_format", "md")
+        )
+        job_queue.task_done()
+
+# Start the queue worker thread
+worker_thread = threading.Thread(target=queue_worker, daemon=True)
+worker_thread.start()
+
 @app.route('/api/upload', methods=['POST'])
 def upload_file():
     if 'file' not in request.files:
@@ -99,12 +125,28 @@ def upload_file():
     file.save(file_path)
 
     job_id = str(uuid.uuid4())
-    active_jobs[job_id] = {"progress": 0, "status": "📤 File uploaded", "cancelled": False, "result": None, "current_page": 0, "total_pages": 0}
+    active_jobs[job_id] = {
+        "progress": 0,
+        "status": "⏳ Queued",
+        "cancelled": False,
+        "result": None,
+        "current_page": 0,
+        "total_pages": 0,
+        "filename": filename
+    }
 
-    thread = threading.Thread(target=run_processing, args=(job_id, file_path, api, model, mode, prompt_key, compression_settings, output_format))
-    thread.start()
+    job_queue.put({
+        "job_id": job_id,
+        "file_path": file_path,
+        "api": api,
+        "model": model,
+        "mode": mode,
+        "prompt_key": prompt_key,
+        "compression_settings": compression_settings,
+        "output_format": output_format
+    })
 
-    return jsonify({"message": "File uploaded, processing started", "job_id": job_id})
+    return jsonify({"message": "File uploaded, job queued", "job_id": job_id})
 
 @app.route('/api/progress/<job_id>', methods=['GET'])
 def get_progress(job_id):
@@ -118,6 +160,10 @@ def get_progress(job_id):
         })
     else:
         return jsonify({"error": "Job not found"}), 404
+
+@app.route('/api/jobs', methods=['GET'])
+def list_jobs():
+    return jsonify({"jobs": active_jobs})
 
 @app.route('/api/stop/<job_id>', methods=['POST'])
 def stop_job(job_id):

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import FileList from './components/FileList';
 import Configurations from './components/Configurations';
 import TxtToPdf from './components/TxtToPdf';
 import MdToEpub from './components/MdToEpub';
+import JobQueue from './components/JobQueue';
 import Notifications from './components/Notifications';
 
 function App() {
@@ -34,7 +35,8 @@ function App() {
     { id: 'files', label: 'Processed Files', icon: '📁', description: 'View and manage processed files' },
     { id: 'configurations', label: 'Settings', icon: '⚙️', description: 'Configure application settings' },
     { id: 'txttopdf', label: 'TXT to PDF', icon: '📝', description: 'Convert text files to PDF' },
-    { id: 'mdtoepub', label: 'MD to EPUB', icon: '📚', description: 'Convert Markdown files to EPUB' }
+    { id: 'mdtoepub', label: 'MD to EPUB', icon: '📚', description: 'Convert Markdown files to EPUB' },
+    { id: 'queue', label: 'Task Queue', icon: '⏳', description: 'View processing tasks' }
   ];
 
   return (
@@ -101,6 +103,7 @@ function App() {
             {activeTab === 'configurations' && <Configurations />}
             {activeTab === 'txttopdf' && <TxtToPdf />}
             {activeTab === 'mdtoepub' && <MdToEpub />}
+            {activeTab === 'queue' && <JobQueue />}
           </div>
         </div>
       </main>

--- a/frontend/src/components/JobQueue.js
+++ b/frontend/src/components/JobQueue.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import ProgressBar from './ProgressBar';
+
+const API_URL = '/api';
+
+function JobQueue() {
+  const [jobs, setJobs] = useState({});
+
+  useEffect(() => {
+    const fetchJobs = () => {
+      axios.get(`${API_URL}/jobs`).then(res => {
+        setJobs(res.data.jobs || {});
+      }).catch(() => {});
+    };
+    fetchJobs();
+    const interval = setInterval(fetchJobs, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const jobIds = Object.keys(jobs);
+
+  if (jobIds.length === 0) {
+    return (
+      <div className="empty-state">
+        <div className="empty-state-icon">⏳</div>
+        <h3 className="empty-state-title">No tasks in queue</h3>
+      </div>
+    );
+  }
+
+  return (
+    <div className="job-queue">
+      {jobIds.map(id => (
+        <div key={id} className="card">
+          <div className="card-header">
+            <h3 className="card-title">{jobs[id].filename || id}</h3>
+          </div>
+          <ProgressBar
+            progress={jobs[id].progress}
+            status={jobs[id].status}
+            currentPage={jobs[id].current_page}
+            totalPages={jobs[id].total_pages}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default JobQueue;


### PR DESCRIPTION
## Summary
- implement queued job processing in backend
- expose `/api/jobs` to list all tasks
- start a worker thread to handle queued jobs
- show queue tab in React app
- display job progress in new `JobQueue` component

## Testing
- `npm test` *(fails: react-scripts missing due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68756d1fc920832e9896a4c2d2196ef1