### PR TITLE
Implement processing queue UI

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -99,7 +99,15 @@ def upload_file():
     file.save(file_path)
 
     job_id = str(uuid.uuid4())
-    active_jobs[job_id] = {"progress": 0, "status": "📤 File uploaded", "cancelled": False, "result": None, "current_page": 0, "total_pages": 0}
+    active_jobs[job_id] = {
+        "progress": 0,
+        "status": "📤 File uploaded",
+        "cancelled": False,
+        "result": None,
+        "current_page": 0,
+        "total_pages": 0,
+        "filename": filename,
+    }
 
     thread = threading.Thread(target=run_processing, args=(job_id, file_path, api, model, mode, prompt_key, compression_settings, output_format))
     thread.start()
@@ -118,6 +126,20 @@ def get_progress(job_id):
         })
     else:
         return jsonify({"error": "Job not found"}), 404
+
+@app.route('/api/jobs', methods=['GET'])
+def list_jobs():
+    jobs = []
+    for jid, info in active_jobs.items():
+        jobs.append({
+            "job_id": jid,
+            "filename": info.get("filename", ""),
+            "progress": info.get("progress", 0),
+            "status": info.get("status", ""),
+            "current_page": info.get("current_page", 0),
+            "total_pages": info.get("total_pages", 0)
+        })
+    return jsonify({"jobs": jobs})
 
 @app.route('/api/stop/<job_id>', methods=['POST'])
 def stop_job(job_id):

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -689,6 +689,35 @@ body {
   transform: translateY(-1px);
 }
 
+/* Processing Queue */
+.queue-container {
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--gray-200);
+}
+
+.queue-title {
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: var(--gray-700);
+  font-size: 0.875rem;
+}
+
+.queue-item {
+  margin-bottom: 1rem;
+}
+
+.queue-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.queue-filename {
+  font-size: 0.875rem;
+  color: var(--gray-800);
+  word-break: break-all;
+}
+
 /* Notifications */
 .notifications-container {
   position: fixed;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import Configurations from './components/Configurations';
 import TxtToPdf from './components/TxtToPdf';
 import MdToEpub from './components/MdToEpub';
 import Notifications from './components/Notifications';
+import ProcessingQueue from './components/ProcessingQueue';
 
 function App() {
   const [activeTab, setActiveTab] = useState('ocrAI');
@@ -81,6 +82,7 @@ function App() {
             </button>
           ))}
         </nav>
+        <ProcessingQueue />
       </aside>
 
       {/* Main Content */}

--- a/frontend/src/components/ProcessingQueue.js
+++ b/frontend/src/components/ProcessingQueue.js
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import ProgressBar from './ProgressBar';
+
+const API_URL = '/api';
+
+function ProcessingQueue() {
+  const [jobs, setJobs] = useState([]);
+
+  useEffect(() => {
+    const fetchJobs = () => {
+      axios.get(`${API_URL}/jobs`)
+        .then(res => setJobs(res.data.jobs))
+        .catch(() => {});
+    };
+    fetchJobs();
+    const interval = setInterval(fetchJobs, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleStop = (jobId) => {
+    axios.post(`${API_URL}/stop/${jobId}`).catch(() => {});
+  };
+
+  if (jobs.length === 0) return null;
+
+  return (
+    <div className="queue-container">
+      <h3 className="queue-title">Processing Queue</h3>
+      {jobs.map(job => (
+        <div key={job.job_id} className="queue-item">
+          <div className="queue-header">
+            <span className="queue-filename">{job.filename}</span>
+            <button
+              onClick={() => handleStop(job.job_id)}
+              className="btn btn-sm btn-danger"
+            >
+              ⏹️
+            </button>
+          </div>
+          <ProgressBar
+            progress={job.progress}
+            status={job.status}
+            currentPage={job.current_page}
+            totalPages={job.total_pages}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default ProcessingQueue;


### PR DESCRIPTION
## Summary
- add filename tracking and job listing endpoint in backend
- implement ProcessingQueue component polling for active jobs
- render processing queue in sidebar
- style queue list in App.css

## Testing
- `npm install` *(fails: registry blocked)*


------
https://chatgpt.com/codex/tasks/task_e_6875922edcac832e817e31b4c2309c1e